### PR TITLE
Switch build script to use Nest CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "src": "dist/src"
   },
   "scripts": {
-    "build": "rimraf dist && tsc",
+    "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nodemon --watch src --exec \"nest start --watch\"",


### PR DESCRIPTION
### Summary
This PR replaces the previous build pipeline (`rimraf dist && tsc`) with the native `nest build` command.

### Why This Change?
- `rimraf` was referenced in the build script but not installed, causing build failures.
- `nest build` already performs a clean build by removing the `dist` directory automatically.
- Ensures consistent, cross-platform builds.
- Aligns the project with NestJS CLI best practices.

### What Changed
- Updated the `build` script in `package.json`:
  - From: `rimraf dist && tsc`
  - To: `nest build`

### Impact
- No breaking changes.
- Build process is simplified and more reliable.
- No additional dependencies required.

### Checklist
- [x] Build script updated
- [x] Tested locally with `npm run build`
- [x] No runtime or deployment impact
